### PR TITLE
MER-673 - Add AUTOMATOR_START_ONLY flag handling

### DIFF
--- a/ci.ps1
+++ b/ci.ps1
@@ -1,4 +1,7 @@
-param( [string]$testSuiteId = $env:AUTOMATOR_TEST_SUITE_ID )
+param( 
+    [string]$testSuiteId = $env:AUTOMATOR_TEST_SUITE_ID,
+    [string]$startOnly = $env:AUTOMATOR_START_ONLY
+)
 
 $secret = $env:AUTOMATOR_USER_KEY_SECRET
 $key_id = $env:AUTOMATOR_USER_KEY_ID
@@ -121,6 +124,11 @@ function Start-Build {
 
     $triggerResponse = Invoke-RestMethod @params;
     Write-Output $triggerResponse;
+
+    if (($startOnly -eq $true) -or ($startOnly -eq 1)) {
+        Write-Output "DeepCrawl Skipped Polling"
+        exit 0
+    }
 
     while ( ($null -eq $testResults) -and (Get-Timeout) ) {
         #poll server

--- a/ci.sh
+++ b/ci.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 testSuiteId=${1:-$AUTOMATOR_TEST_SUITE_ID}
+startOnly=${2:-$AUTOMATOR_START_ONLY}
 
 if [ -z $testSuiteId ]; then
     exit "No TestSuite Id Set"
@@ -53,6 +54,11 @@ function StartBuild() {
     local body="{\"authToken\":\"$authToken\",\"testSuiteId\":\"$testSuiteId\"}"
     RESPONSE=$(curl -s -X POST "https://beta-triggers.deepcrawl.com/start" -H "Content-Type:application/json" -d $body)
     resp=$(echo $RESPONSE | jq '.buildId')
+
+    if [ "$startOnly" = "true" ] || [ "$startOnly" = "1" ]; then
+        echo "DeepCrawl Skipped Polling"
+        exit 0
+    fi
 
     if [ $? -eq 0 ]; then
         until [[ $testResults && $totalRunTime -lt $maxRunTime ]]; do

--- a/docs/ci-scripts.md
+++ b/docs/ci-scripts.md
@@ -71,16 +71,11 @@ steps:
 
 Run either script with the correct environment variables. This should start the test suite build and poll for results.
 
-### Preventing Automator from delaying or blocking builds
-Crawling a test environment can take several minutes depending on the configured speed and number of URLs. During your initial usage of Automator, you may not want Automator to delay your builds, or have the ability to block a deployment.
-In this case, you can configure the shell script to have a "start only" behaviour. 
+## Using Automator scripts without blocking builds
 
-Under this strategy, the bash script will start a crawl of the environment then immediate return a passed status. The crawl will continue in the background and will send a notification of the test results on completion.
+From time to time, you may want to use Automator without letting your CI system wait for the crawl to complete, or allowing the script impact whether your build succeeds. In this case, you can add the `AUTOMATOR_START_ONLY` environment variable set to `true` or `1`. You can also pass the value as a second script argument after test suite ID. This flag modifies the behaviour of the script to start a test suite test, then return without polling for a result.
 
-Native support for a "start only" mode is coming to the shell scripts soon. To achieve this in the meantime, you should modify the shell script to exit with a `0` status immediately after making the 'Start Build' request.
-For instance,
-- in [`ci.sh`](https://github.com/deepcrawl/automator-sdk/blob/master/ci.sh), add `exit 0` before the `until` loop in the `StartBuild` function
-- in [`ci.ps`](https://github.com/deepcrawl/automator-sdk/blob/master/ci.ps), add `exit 0` before the `while` loop in the `Start-Build` function
+In this case Automator will send an email or other notification about the status of your tests, and the test results will be available in the automator app.
 
 ## Debugging
 

--- a/docs/ci-scripts.md
+++ b/docs/ci-scripts.md
@@ -14,6 +14,8 @@ AUTOMATOR_USER_KEY_ID (Key ID for generated API Key)
 AUTOMATOR_USER_KEY_SECRET (Secret value for generated API Key)
 
 AUTOMATOR_TEST_SUITE_ID (optional) // can be passed into ci as param
+
+AUTOMATOR_START_ONLY (optional, set to `1` or `true` to run Automator without blocking a build)
 ```
 
 example:


### PR DESCRIPTION
You can set the flag in three ways:
- By setting exported AUTOMATOR_START_ONLY env variable  in the system to `true` or `1`
- Passing it as a script param:
`> sh ./ci.sh suiteid true`
`> pwsh./ci.ps1 -testSuiteId asdasd -startOnly 1`
- Including env variable before the script command, e.g.
`> AUTOMATOR_START_ONLY=1 sh ./ci.sh suiteid`

Param will overwrite exported env variable.

@kiwialec I've updated the doc text so please review it.

JIRA ticket: https://deepcrawl.atlassian.net/browse/MER-673